### PR TITLE
Mismatch In Joint Tessellation Factor

### DIFF
--- a/all/native/renderers/drawdatas/LineDrawData.cpp
+++ b/all/native/renderers/drawdatas/LineDrawData.cpp
@@ -144,7 +144,7 @@ namespace carto {
                     if (style.getLineJoinType() == LineJoinType::LINE_JOIN_TYPE_BEVEL) {
                         segments = deltaAngle != 0 ? 1 : 0;
                     } else { //style.getLineJoinType() == LineJoinType::ROUND
-                        segments = static_cast<int>(std::ceil(std::abs(deltaAngle) * style.getWidth() * LINE_ENDPOINT_TESSELATION_FACTOR));
+                        segments = static_cast<int>(std::ceil(std::abs(deltaAngle) * style.getWidth() * LINE_JOIN_TESSELATION_FACTOR));
                     }
     
                     coordCount += segments;


### PR DESCRIPTION
First, in the part of the initialization that estimates the number of coordinates and indices, there is a mistake in estimating the number of joint segments when the join type is round, and it uses the tesselation factor of endpoints for joints. Whereas, during calculate joints coordinates and others it uses the right one. So there is a mismatch.

Second, the tesselation factor is too low. The joints with round join type are the same as the bevel ones. I think there is a need to increase the tesselation factor. But I did not change it. Consider please